### PR TITLE
Minor fixes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM aica-technology/ros-ws:noetic
+FROM ghcr.io/aica-technology/ros-ws:noetic
 
-RUN sudo apt update && sudo apt install -y ros-noetic-turtlesim && rm -rf /var/lib/apt/lists/*
+RUN sudo apt update && sudo apt install -y ros-noetic-turtlesim && sudo rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/${USER}/ros_ws
 COPY --chown=${USER} ./turtle_example ./src/


### PR DESCRIPTION
Docker build failed due to :
-FROM line : 'pull access denied for aica-technology/ros-ws, repository does not exist or may require 'docker login': denied: requested access to the resource is denied'
-'Permission denied' error when trying to remove /var/lib/apt/lists/*


